### PR TITLE
feat(caipe): update ai-platform-engineering chart to 0.2.6

### DIFF
--- a/caipe/base/ai-platform-engineering.yaml
+++ b/caipe/base/ai-platform-engineering.yaml
@@ -11,7 +11,7 @@ spec:
     # Main chart from GHCR
     - chart: ai-platform-engineering
       repoURL: ghcr.io/cnoe-io/helm-charts
-      targetRevision: 0.2.5
+      targetRevision: 0.2.6
       helm:
         parameters:
         - name: tags.basic


### PR DESCRIPTION
## Update ai-platform-engineering chart version

### Changes
- Bump chart version from 0.2.5 to 0.2.6
- Includes fix for ExternalSecret validation error in kb-rag-agent
- Resolves tags.complete deployment failures

### Related
- Upstream PR: https://github.com/cnoe-io/ai-platform-engineering/pull/325
- Fixes ExternalSecret validation when data is empty

### Testing
- Chart version updated in caipe/base stack
- Ready for deployment once upstream chart is published